### PR TITLE
Use LittleBigRefresh as the primary source for asset downloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,13 +101,19 @@ impl ResrcId {
 async fn download_res(sha1: &str, path: &str, client: &mut Client) -> Result<(), ()> {
     println!("Downloading {sha1}...");
 
-    let url = format!("https://archive.org/download/dry23r{}/dry{}.zip/{}%2F{}%2F{}", sha1.chars().next().unwrap(), &sha1[..2], &sha1[..2], &sha1[2..4], sha1);
-
+    let mut url = format!("https://lbp.littlebigrefresh.com/api/v3/assets/{}/download", sha1);
     let mut resp = client.get(url).send().await.unwrap();
-
+    
     if resp.status() != 200 {
-        println!("Resource download {sha1} failed with HTTP status code {}, skipping...", resp.status());
-        return Err(())
+        println!("Resource download {sha1} failed with HTTP status code {}, trying from archive.org...", resp.status());
+
+        url = format!("https://archive.org/download/dry23r{}/dry{}.zip/{}%2F{}%2F{}", sha1.chars().next().unwrap(), &sha1[..2], &sha1[..2], &sha1[2..4], sha1);
+        resp = client.get(url).send().await.unwrap();
+
+        if resp.status() != 200 {
+            println!("Resource download {sha1} failed with HTTP status code {}, skipping...", resp.status());
+            return Err(())
+        }
     }
 
     let mut file = File::create(&path).unwrap();


### PR DESCRIPTION
Recently we introduced a feature that will let the Dry Archive's directory structure be used behind Refresh's normal data store. This means that all hashes stored in the archive can be referenced in addition to Refresh's users' content.

Using our API is much much faster than downloading from Archive.org, since we've downloaded the full archive on our server and extracted it so everything's right there on the disk, so no parsing the zip files, no reaching out to archive.org, etc.. In addition, we have CloudFlare caching all the assets once downloaded.

I tested this with one of my levels and downloading just 7 assets that are about 220K in size is much much faster, beating archive.org by a few seconds.

This PR uses that public API to speed things up, but uses archive.org as a fallback for when things go south on our end.

---

As a side-note, I'm not too familiar with Rust so apologies if I'm breaking any conventions, but what I did seems to work pretty well.