### PR TITLE
Add LBPSearch download mirror

### DIFF
--- a/src/assets/default_config.yml
+++ b/src/assets/default_config.yml
@@ -11,6 +11,7 @@ backup_directory: "backups"
 # Server where level resources are downloaded from
 # Values are:
 # - "bonsai" (https://lbp.lbpbonsai.com/)
+# - "lbpsearch" (https://zaprit.fish/)
 # - "archive" (https://archive.org/details/@tamiya99)
 download_server: "bonsai"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 const DEFAULT_CONFIG: &[u8] = include_bytes!("assets/default_config.yml");
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 pub enum DownloadServer {
     Bonsai,
     Refresh,

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ const DEFAULT_CONFIG: &[u8] = include_bytes!("assets/default_config.yml");
 pub enum DownloadServer {
     Bonsai,
     Refresh,
+    LbpSearch,
     Archive,
 }
 
@@ -17,6 +18,7 @@ impl DownloadServer {
         let h = hex::encode(sha1);
         match self {
             Self::Bonsai | Self::Refresh => format!("https://lbp.lbpbonsai.com/api/v3/assets/{}/download", h),
+            Self::LbpSearch => format!("https://lbparchive.zaprit.fish/{}/{}/{}", &h[..2], &h[2..4], h),
             Self::Archive => format!("https://archive.org/download/dry23r{}/dry{}.zip/{}%2F{}%2F{}", h.chars().next().unwrap(), &h[..2], &h[..2], &h[2..4], h),
         }
     }


### PR DESCRIPTION
As part of zaprit.fish I host a download mirror for the LBP archive on backblaze b2, it's backed by cloudflare and should be pretty fast, at least faster than archive.org. This PR adds it as an available download server to fetch resources from.