### PR TITLE
Fix crash on null icon

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -113,6 +113,9 @@ pub fn get_slot_info(id: i64, db_path: &Path) -> Result<SlotInfo> {
                     let bytes = bytes.try_into().map_err(|_| anyhow!("invalid icon in db"))?;
                     ResrcDescriptor::Guid(u32::from_be_bytes(bytes))
                 },
+                0 => {
+                    ResrcDescriptor::Guid(0)
+                },
                 _ => return Err(anyhow!("invalid icon in db")),
             }
         },


### PR DESCRIPTION
On certain levels in the archive the icon is null, this causes a panic due to it being an invalid icon, this just sets it to a 0 guid, which the game seems to accept.

Example of a level with the issue: https://zaprit.fish/slot/2094903